### PR TITLE
Don't try to use shindent, it is too broken

### DIFF
--- a/rpm-spec-mode.el
+++ b/rpm-spec-mode.el
@@ -666,10 +666,7 @@ Turning on RPM spec mode calls the value of the variable `rpm-spec-mode-hook'
 with no args, if that value is non-nil."
   (interactive)
   (kill-all-local-variables)
-  (condition-case nil
-      (require 'shindent)
-    (error
-     (require 'sh-script)))
+  (require 'sh-script)
   (require 'cc-mode)
   (use-local-map rpm-spec-mode-map)
   (setq major-mode 'rpm-spec-mode)


### PR DESCRIPTION
Compiling it produces these warnings:

```
Compiling file /tmp/shindent/shindent.el at Fri Dec 30 19:29:27 2016
Entering directory `/tmp/shindent/'
shindent.el:366:7:Warning: assignment to free variable `shi-symbol-list'
shindent.el:388:15:Warning: reference to free variable `shi-symbol-list'
shindent.el:382:7:Warning: assignment to free variable
    `shi-number-or-symbol-list'
shindent.el:403:21:Warning: reference to free variable
    `shi-number-or-symbol-list'
shindent.el:539:7:Warning: assignment to free variable `shi-re-done'

In shi-make-vars-local:
shindent.el:610:4:Warning: `mapcar' called for effect; use `mapc' or `dolist'
    instead

In shi-reset-indent-vars-to-global-values:
shindent.el:618:4:Warning: `mapcar' called for effect; use `mapc' or `dolist'
    instead

In shi-help-string-for-variable:
shindent.el:757:21:Warning: (lambda (x) ...) quoted with ' rather than with #'
shindent.el:760:33:Warning: reference to free variable `shi-symbol-list'

In shi-goto-match-for-done:
shindent.el:930:60:Warning: reference to free variable `shi-re-done'

In shi-mark-init:
shindent.el:1842:10:Warning: Use `with-current-buffer' rather than
    save-excursion+set-buffer
shindent.el:1847:13:Warning: assignment to free variable `occur-buffer'

In shi-mark-line:
shindent.el:1870:15:Warning: assignment to free variable `occur-buffer'

In shi-learn-buffer-indent:
shindent.el:2142:26:Warning: Use `with-current-buffer' rather than
    save-excursion+set-buffer

In shi-guess-basic-offset:
shindent.el:2197:21:Warning: (lambda (a b) ...) quoted with ' rather than with
    #'

In shi-electric-less:
shindent.el:2310:16:Warning: `sh-maybe-here-document' is an obsolete function
    (as of 24.3); use `sh-electric-here-document-mode' instead.

In shi-save-styles-to-buffer:
shindent.el:2584:6:Warning: Use `with-current-buffer' rather than
    save-excursion+set-buffer

Compiling file /tmp/shindent/shindent.el at Fri Dec 30 19:29:29 2016
shindent.el:366:7:Warning: assignment to free variable `shi-symbol-list'
shindent.el:388:15:Warning: reference to free variable `shi-symbol-list'
shindent.el:382:7:Warning: assignment to free variable
    `shi-number-or-symbol-list'
shindent.el:403:21:Warning: reference to free variable
    `shi-number-or-symbol-list'
shindent.el:539:7:Warning: assignment to free variable `shi-re-done'

In shi-make-vars-local:
shindent.el:610:4:Warning: `mapcar' called for effect; use `mapc' or `dolist'
    instead

In shi-reset-indent-vars-to-global-values:
shindent.el:618:4:Warning: `mapcar' called for effect; use `mapc' or `dolist'
    instead

In shi-help-string-for-variable:
shindent.el:760:33:Warning: reference to free variable `shi-symbol-list'

In shi-goto-match-for-done:
shindent.el:930:60:Warning: reference to free variable `shi-re-done'

In shi-mark-init:
shindent.el:1842:10:Warning: Use `with-current-buffer' rather than
    save-excursion+set-buffer
shindent.el:1847:13:Warning: assignment to free variable `occur-buffer'

In shi-mark-line:
shindent.el:1870:15:Warning: assignment to free variable `occur-buffer'

In shi-learn-buffer-indent:
shindent.el:2142:26:Warning: Use `with-current-buffer' rather than
    save-excursion+set-buffer

In shi-guess-basic-offset:
shindent.el:2197:21:Warning: (lambda (a b) ...) quoted with ' rather than with
    #'

In shi-electric-less:
shindent.el:2310:16:Warning: `sh-maybe-here-document' is an obsolete function
    (as of 24.3); use `sh-electric-here-document-mode' instead.

In shi-save-styles-to-buffer:
shindent.el:2584:6:Warning: Use `with-current-buffer' rather than
    save-excursion+set-buffer
```