### PR TITLE
Use zero-padded date (%d) instead of space-padded date (%e)

### DIFF
--- a/rpm-spec-mode.el
+++ b/rpm-spec-mode.el
@@ -1,8 +1,8 @@
 ;;; rpm-spec-mode.el --- RPM spec file editing commands for Emacs/XEmacs
 
-;; Copyright (C) 1997-2015 Stig Bjørlykke, <stig@bjorlykke.org>
+;; Copyright (C) 1997-2015 Stig BjÃ¸rlykke, <stig@bjorlykke.org>
 
-;; Author:   Stig Bjørlykke, <stig@bjorlykke.org>
+;; Author:   Stig BjÃ¸rlykke, <stig@bjorlykke.org>
 ;; Keywords: unix, languages
 ;; Version:  0.16
 
@@ -30,10 +30,10 @@
 ;;     Tore Olsen <toreo@tihlde.org> for some general fixes.
 ;;     Steve Sanbeg <sanbeg@dset.com> for navigation functions and
 ;;          some Emacs fixes.
-;;     Tim Powers <timp@redhat.com> and Trond Eivind Glomsrød
+;;     Tim Powers <timp@redhat.com> and Trond Eivind GlomsrÃ¸d
 ;;          <teg@redhat.com> for Red Hat adaptions and some fixes.
 ;;     Chmouel Boudjnah <chmouel@mandrakesoft.com> for Mandrake fixes.
-;;     Ville Skyttä  <ville.skytta@iki.fi> for some fixes.
+;;     Ville SkyttÃ¤  <ville.skytta@iki.fi> for some fixes.
 ;;     Adam Spiers <elisp@adamspiers.org> for GNU emacs compilation
 ;;          and other misc fixes.
 
@@ -1460,7 +1460,7 @@ if one is present in the file."
   (message
    (concat "rpm-spec-mode version "
            rpm-spec-mode-version
-           " by Stig Bjørlykke, <stig@bjorlykke.org>")))
+           " by Stig BjÃ¸rlykke, <stig@bjorlykke.org>")))
 
 ;;;###autoload(add-to-list 'auto-mode-alist '("\\.spec\\(\\.in\\)?$" . rpm-spec-mode))
 

--- a/rpm-spec-mode.el
+++ b/rpm-spec-mode.el
@@ -734,7 +734,7 @@ This variable is global by default, but you can make it buffer-local.")
 (defsubst rpm-change-log-date-string ()
   "Return the date string for today, inserted by \\[rpm-add-change-log-entry].
 If `rpm-change-log-uses-utc' is nil, \"today\" means the local time zone."
-  (format-time-string "%a %b %e %Y" nil rpm-change-log-uses-utc))
+  (format-time-string "%a %b %d %Y" nil rpm-change-log-uses-utc))
 
 (defun rpm-goto-add-change-log-header ()
   "Find change log and add header (if needed) for today"


### PR DESCRIPTION
Both rpmdev-bumpspec and rpm -q --changelog uses zero-padded dates, while the emacs rpm-spec-mode uses space padded dates. This means every time I use the emacs rpm-spec-mode to add changelog entry during the first 9 days of every month I have to remember to replace the space with a zero to keep the format consistent.

This PR addresses this annoyance.

With the proposed changed:

    * Fri Nov 01 2019 Mattias Ellert <mattias.ellert@physics.uu.se> - 0.16-8

Before the proposed change:

    * Fri Nov  1 2019 Mattias Ellert <mattias.ellert@physics.uu.se> - 0.16-8
